### PR TITLE
Laravel11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
         }
     ],
     "require": {
-        "php": "^8.0|^8.1",
-        "illuminate/contracts": "^9.0 | ^10.0",
+        "php": "^8.0|^8.1|^8.2|^8.3|^8.4",
+        "illuminate/contracts": "^9.0|^10.0|^11.0",
         "setasign/fpdf": "1.8.*",
         "setasign/fpdi": "^2.0",
         "spatie/browsershot": "^4.0",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "illuminate/contracts": "^9.0|^10.0|^11.0",
         "setasign/fpdf": "1.8.*",
         "setasign/fpdi": "^2.0",
-        "spatie/browsershot": "^4.0",
+        "spatie/browsershot": "^5.0",
         "spatie/laravel-package-tools": "^1.4.3",
         "wnx/sidecar-browsershot": "^2.3"
     },

--- a/config/printable.php
+++ b/config/printable.php
@@ -5,5 +5,6 @@ use Orlyapps\Printable\Support\StationeryResolver\DefaultStationeryResolver;
 return [
     'middleware' => ['web', 'nova'],
     'stationery_resolver' => DefaultStationeryResolver::class,
-    'tailwindConfig' => __DIR__ . "/../resources/tailwind.config.js"
+    'tailwindConfig' => __DIR__ . "/../resources/tailwind.config.js",
+    'timeout' => 5,
 ];

--- a/src/PrintModel.php
+++ b/src/PrintModel.php
@@ -131,7 +131,7 @@ class PrintModel
             ->noSandbox()
             ->waitUntilNetworkIdle(false)
             ->delay(2000)
-            ->timeout(config('printable.timeout'));
+            ->timeout(config('printable.timeout', 5));
 
         $shot = $this->model->browsershot($shot);
 

--- a/src/PrintModel.php
+++ b/src/PrintModel.php
@@ -131,7 +131,7 @@ class PrintModel
             ->noSandbox()
             ->waitUntilNetworkIdle(false)
             ->delay(2000)
-            ->timeout(5);
+            ->timeout(config('printable.timeout'));
 
         $shot = $this->model->browsershot($shot);
 


### PR DESCRIPTION
additional config setting for timeout
after upgrade to L11 there has been sporadic issues with timeout of 5 - 10 worked in most cases, but even then often timeouts was reached - so after increasing to 30 our project runs well. Whyever (with L10 Timeout of 5 worked fine).